### PR TITLE
updates transactionId value to orderId

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsIntegration.java
@@ -3,6 +3,7 @@ package com.segment.analytics.android.integrations.google.analytics;
 import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
+
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.HitBuilders.TransactionBuilder;
 import com.segment.analytics.Analytics;
@@ -15,6 +16,7 @@ import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 import com.segment.analytics.internal.Utils;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -177,7 +179,7 @@ public class GoogleAnalyticsIntegration
         for (int i = 0; i < products.size(); i++) {
           Product product = products.get(i);
           ItemHitBuilder hitBuilder = new ItemHitBuilder();
-          hitBuilder.setTransactionId(product.id())
+          hitBuilder.setTransactionId(properties.orderId())
               .setName(product.name())
               .setSku(product.sku())
               .setPrice(product.price())
@@ -297,7 +299,7 @@ public class GoogleAnalyticsIntegration
     }
 
     ItemHitBuilder itemHitBuilder = new ItemHitBuilder();
-    itemHitBuilder.setTransactionId(properties.productId())
+    itemHitBuilder.setTransactionId(properties.orderId())
         .setCurrencyCode(properties.currency())
         .setName(properties.name())
         .setSku(properties.sku())

--- a/src/test/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsTest.java
@@ -202,7 +202,7 @@ public class GoogleAnalyticsTest {
   }
 
   @Test public void sendProductEvent() {
-    Properties properties = new Properties().putProductId("foo")
+    Properties properties = new Properties().putOrderId("foo")
         .putCurrency("bar")
         .putName("baz")
         .putSku("qaz")
@@ -226,7 +226,7 @@ public class GoogleAnalyticsTest {
     integration.customDimensions = new ValueMap().putValue("customDimension", "dimension2");
     integration.customMetrics = new ValueMap().putValue("customMetric", "metric3");
 
-    Properties properties = new Properties().putProductId("foo")
+    Properties properties = new Properties().putOrderId("foo")
         .putCurrency("bar")
         .putName("baz")
         .putSku("qaz")


### PR DESCRIPTION
We had been mapping `product.id` to `transactionId`. Each `order id` should actually match the `transactionId`: https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce#transaction
