### PR TITLE
Add support for product level custom dimensions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     jcenter()
   }
 
-  compile 'com.segment.analytics.android:analytics:4.0.0'
+  compile 'com.segment.analytics.android:analytics:4.3.0'
 
   compile 'com.google.android.gms:play-services-analytics:11.4.2'
 
@@ -53,7 +53,7 @@ dependencies {
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }
 
-  testCompile 'com.segment.analytics.android:analytics-tests:4.0.0'
+  testCompile 'com.segment.analytics.android:analytics-tests:4.3.0'
 
   testCompile 'org.assertj:assertj-core:1.7.1'
 


### PR DESCRIPTION
Previously, custom dimensions could not be sent on a per product basis to Google Analytics. Custom dimensions would only be sent based on the top level properties. e.g. when sending `{ properties: { foo: "foo_val", products: { bar: "bar_val" } } }` only `foo_val` would be sent as dimension1. This change allows sending `bar_val` as `dimension2`.

Additionally, the product level hits sent to Google Analytics pulled some fields from the top level properties object, instead of the more tightly scoped product properties. e.g. when sending `{ properties: { id: "id", products: { id: "product_id" } } }`, only `id` would be sent in the product hit, when the correct behaviour would be to use `product_id`. This change allows sending `product_id` in the product hit.

To preserve backward compatibility, customDimensions on the product hit are set twice (once for the product map, and once for the event map).

This requires updating the minimum compatible version of our core SDK to take advantage of some bug fixes related to ecommerce events (specifically segmentio/analytics-android@8649050).