### PR TITLE
Send Campaign Params from Deep Link URL Opened 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=2.0.3
+VERSION=2.1.0-SNAPSHOT
 
 POM_ARTIFACT_ID=google-analytics
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsIntegration.java
@@ -234,6 +234,10 @@ public class GoogleAnalyticsIntegration
     attachCustomDimensionsAndMetrics(eventHitBuilder, properties);
     attachCampaignData(eventHitBuilder, track);
 
+    if (event.equals("Deep Link Opened")) {
+      eventHitBuilder.setCampaignParamsFromUrl(track.properties().getString("url"));
+    }
+
     Map<String, String> eventHit = eventHitBuilder.build();
     tracker.send(eventHit);
     logger.verbose("tracker.send(%s);", eventHit);
@@ -334,6 +338,9 @@ public class GoogleAnalyticsIntegration
       return;
     }
 
+    BasePayload payload1 = payload;
+
+//    String utm_id = payload.properties().getString("utm_id")
     String url = new Uri.Builder().appendQueryParameter("utm_content", campaign.content())
         .appendQueryParameter("utm_source", campaign.source())
         .appendQueryParameter("utm_medium", campaign.medium())

--- a/src/main/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsIntegration.java
@@ -338,9 +338,7 @@ public class GoogleAnalyticsIntegration
       return;
     }
 
-    BasePayload payload1 = payload;
-
-//    String utm_id = payload.properties().getString("utm_id")
+    
     String url = new Uri.Builder().appendQueryParameter("utm_content", campaign.content())
         .appendQueryParameter("utm_source", campaign.source())
         .appendQueryParameter("utm_medium", campaign.medium())

--- a/src/test/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/google/analytics/GoogleAnalyticsTest.java
@@ -16,10 +16,7 @@ import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
-import java.lang.reflect.Constructor;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,12 +24,16 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 
+import java.lang.reflect.Constructor;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
 import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
 import static com.segment.analytics.Utils.createTraits;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -221,6 +222,16 @@ public class GoogleAnalyticsTest {
         .setCampaignParamsFromUrl(
             "utm_content=newsletter&utm_source=email&utm_medium=online&utm_campaign=coupons")
         .build());
+  }
+
+  @Test public void trackDeepLinkURL() {
+    integration.track((new TrackPayload.Builder()).anonymousId("1234").event("Deep Link Opened").properties(new Properties().putValue("url", "app://track.com/open?utm_id=12345&gclid=abcd&nope=")).build());
+    verify(tracker).send(new HitBuilders.EventBuilder().setCategory("All")
+            .setAction("Deep Link Opened")
+            .setCampaignParamsFromUrl("utm_id=12345&gclid=abcd")
+            .setLabel(null)
+            .setValue(0)
+            .build());
   }
 
   @Test public void trackECommerceEventWithCustomDimensionsAndProducts() {


### PR DESCRIPTION
Leverage the `"url"` from properties which is present on a track "Deep Link Opened" event. https://github.com/segmentio/analytics-android/blob/01d26bf09ba99d36ec851ce36c8bb39c6389de7c/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java#L109

Send the campaign parameters to Google Analytics using: setCampaignParametersFromUrl. Documentation here: https://developers.google.com/android/reference/com/google/android/gms/analytics/HitBuilders.HitBuilder.html#setCampaignParamsFromUrl(java.lang.String)

Verified through unit test and by firing "Deep Link Opened" track event with url `"app://track.com/open?utm_id=12345&gclid=abcd&nope="` and observing the following output in the Android Studio debugging console:
<img width="439" alt="Screen Shot 2020-01-09 at 4 04 36 PM" src="https://user-images.githubusercontent.com/31782219/72114854-c4e7ea00-32f9-11ea-8783-45dea6b1322e.png">